### PR TITLE
Add partial query string support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,29 +9,35 @@ yarn add redux-saga-first-router history
 ```
 
 ## Setup
+
 Keeping browser URL in sync with `redux` state and activating/deactivating application behavior per screen level is handled by [redux-saga](https://github.com/redux-saga/redux-saga).
 
 Router `reducer` is registered as usual in `combineReducers` block. Router `saga` is our workhorse which is registered with `redux-saga` middleware after all other `saga`-s and is initialized with application `routesMap` and instance of `history` helper.
 
 ```js
 import createHistory from 'history/createBrowserHistory';
-import { reducer as routerReducer, saga as routerSaga, buildRoutesMap, route } from 'redux-saga-first-router';
+import {
+	reducer as routerReducer,
+	saga as routerSaga,
+	buildRoutesMap,
+	route,
+} from 'redux-saga-first-router';
 
 // matched from top to bottom
 // less specific routes should appear later
 // provided sagas are activated/deactivated on matched route
 const routesMap = buildRoutesMap(
-    route('PROJECT', '/portal/projects/:projectName', projectNavigate),
-    route('PROJECTS', '/portal/projects', projectsNavigate),
-    route('DOWNLOAD', '/portal/download'),
-    // ...
+	route('PROJECT', '/portal/projects/:projectName', projectNavigate),
+	route('PROJECTS', '/portal/projects', projectsNavigate),
+	route('DOWNLOAD', '/portal/download')
+	// ...
 );
 
 const history = createHistory();
 
 const reducer = combineReducers({
-    // ... other reducers
-    routing: routerReducer
+	// ... other reducers
+	routing: routerReducer,
 });
 
 // ... store and saga middleware setup
@@ -56,46 +62,50 @@ sagaMiddleware.run(routerSaga, routesMap, history);
 }
 ```
 
-* _`id: {string}`_ - should be unique and is part of all `dispatch`-ed `redux` actions.
-* _`path: {string}`_ - Express-style path definition, for reference check [Path-to-RegExp](https://github.com/pillarjs/path-to-regexp) documentation (only paths are supported, no query strings).
-* _`saga: {function*}`_ - [optional] `saga` that will be `fork`-ed when navigated to matching route and `cancel`-ed when navigated away.
+-   _`id: {string}`_ - should be unique and is part of all `dispatch`-ed `redux` actions.
+-   _`path: {string}`_ - Express-style path definition, for reference check [Path-to-RegExp](https://github.com/pillarjs/path-to-regexp) documentation (only paths are supported, no query strings).
+-   _`saga: {function*}`_ - [optional] `saga` that will be `fork`-ed when navigated to matching route and `cancel`-ed when navigated away.
 
 Routes are evaluated from top to bottom until URL match is found, this requires routes to be ordered from more to less specific.
 
 `routesMap` is used to provide data for two essential functions:
 
-* _URL -> Action_ - When URL is entered in browser address bar (or Back/Forward buttons are used) a scan trough `routesMap` tries to find match and when found an action is dispatched
+-   _URL -> Action_ - When URL is entered in browser address bar (or Back/Forward buttons are used) a scan trough `routesMap` tries to find match and when found an action is dispatched
 
 ```js
 {
     type: 'router/NAVIGATE',
     id: 'PROJECT',
-    params: {
-        projectName: 'Project 123'
-    }
+    params: { projectName: 'Project 123' },
+    query: { mode: 'grid' }
 }
 ```
 
-* _Action -> URL_ - When `NAVIGATE` action is dispatched by our code a matching route by `id` is used to generate the corresponding URL and is `push/replace`-ed in browser history.
+-   _Action -> URL_ - When `NAVIGATE` action is dispatched by our code a matching route by `id` is used to generate the corresponding URL and is `push/replace`-ed in browser history.
 
 ```js
 import { navigate } from 'redux-saga-first-router';
 
 const mapDispatchToProps = dispatch => {
-    return {
-        // ...
-        onSelectProject(projectName) {
-            dispatch(navigate('PROJECT', { projectName }));
-        },
-        onProjectDeleted() {
-            dispatch(navigate('PROJECTS', {}, { replace: true }));
-        },
-        // ...
-    }
-}
+	return {
+		// ...
+		onSelectProject(projectName) {
+			dispatch(navigate('PROJECT', { projectName }, { query: { mode: 'grid' } }));
+		},
+		onProjectDeleted() {
+			dispatch(navigate('PROJECTS', {}, { replace: true }));
+		},
+		// ...
+	};
+};
 ```
 
-Where `navigate` is small action creator helper. The third parameter can be used to pass additional options, currently only `replace` is supported and instructs the router to use `replace` instead of `push` method on history update.
+Where `navigate` is small action creator helper. The third parameter can be used to pass additional options, currently supported are:
+
+-   _`replace: {boolean}`_ - instructs the router to use `replace` instead of `push` method on history update.
+-   _`query: {object}`_ - appends query string parameters to generated URL, these will be passed later as second parameter of activated navigate saga.
+
+Query string parameters are unordered/arbitrary data, they are always optional and not considered in route matching.
 
 ## All navigation in our application is now controlled by **just dispatching redux actions**, browser URL and history manipulation are handled automatically and **only by the router** ! If you want to react on navigation event, use registered route **saga**!
 
@@ -113,10 +123,10 @@ import ProjectList from './screens/project-list';
 import NotFound from './screens/not-found';
 
 const Screen = ({ id, params }) =>
-    (({
-        PROJECT: () => <ProjectView projectName={params.projectName} />,
-        PROJECTS: () => <ProjectList />,
-    }[id] || (() => <NotFound />))());
+	(({
+		PROJECT: () => <ProjectView projectName={params.projectName} />,
+		PROJECTS: () => <ProjectList />,
+	}[id] || (() => <NotFound />))());
 
 export default connect(state => state.routing)(Screen);
 ```
@@ -130,25 +140,33 @@ Directly using `redux routing` state beside main React routing component is rare
 The third parameter in our `route` definition is optional `saga` function, as we already mentioned this `saga` will be activated once our application navigates to this `route` and will be `cancel`-ed when navigated away.
 
 ```js
-export function* projectNavigate({ projectName }) {
-    // sub-saga active only for current route
-    yield fork(watchProjectRename); 
+export function* projectNavigate(params, query) {
+	const { projectName } = params;
+	const { mode } = query;
 
-    // prepare initial state
-    yield put(clearStore());
-    try {
-        // poll for changes every 3 seconds
-        while (true) {
-            // load current project
-            yield put(getProject(projectName));
-            yield call(delay, 3000);
-        }
-    } finally {
-        if (yield cancelled()) {
-            // cleanup on navigating away
-            yield put(clearStore());
-        }
-    }
+	// sub-saga active only for current route
+	yield fork(watchProjectRename);
+
+	// prepare initial state
+	yield put(clearStore());
+
+	if (mode) {
+		yield put(setViewMode(mode));
+	}
+
+	try {
+		// poll for changes every 3 seconds
+		while (true) {
+			// load current project
+			yield put(getProject(projectName));
+			yield call(delay, 3000);
+		}
+	} finally {
+		if (yield cancelled()) {
+			// cleanup on navigating away
+			yield put(clearStore());
+		}
+	}
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,22 +1,14 @@
 {
 	"name": "redux-saga-first-router",
-	"version": "0.0.13",
+	"version": "0.0.14",
 	"description": "'Saga First' Router for React/Redux/Saga Projects",
 	"main": "lib/index.js",
 	"module": "lib/es/index.js",
 	"repository": "https://github.com/ChaosGroup/redux-saga-first-router",
 	"author": "ChaosGroup (c) 2013-2017",
 	"license": "MIT",
-	"keywords": [
-		"react",
-		"redux",
-		"redux-saga",
-		"router"
-	],
-	"files": [
-		"src",
-		"lib"
-	],
+	"keywords": ["react", "redux", "redux-saga", "router"],
+	"files": ["src", "lib"],
 	"devDependencies": {
 		"babel-cli": "^6.24.1",
 		"babel-core": "^6.25.0",
@@ -52,8 +44,6 @@
 	},
 	"jest": {
 		"moduleNameMapper": {},
-		"roots": [
-			"<rootDir>/src/"
-		]
+		"roots": ["<rootDir>/src/"]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"babel-runtime": "^6.26.0",
 		"history": "^4.6.3",
 		"path-to-regexp": "^1.7.0",
+		"query-string": "^6.1.0",
 		"redux-saga": "^0.15.6"
 	},
 	"scripts": {

--- a/src/__tests__/actionToPath.test.js
+++ b/src/__tests__/actionToPath.test.js
@@ -24,6 +24,15 @@ describe('actionToPath', () => {
 		}).toThrow();
 	});
 
+	test('defined route, with params and query', () => {
+		expect(
+			actionToPath(
+				routesMap,
+				navigate('PROJECT', { projectName: 'Project 123' }, { query: { returnTo: 'home' } })
+			)
+		).toBe('/portal/projects/Project%20123?returnTo=home');
+	});
+
 	test('undefined route', () => {
 		expect(actionToPath(routesMap, navigate('UNDEFINED'))).toBe(null);
 	});

--- a/src/__tests__/pathToAction.test.js
+++ b/src/__tests__/pathToAction.test.js
@@ -17,9 +17,23 @@ describe('pathToAction', () => {
 		);
 	});
 
+	test('defined route, with params, with search', () => {
+		expect(pathToAction(routesMap, '/portal/projects/Project123', '?returnTo=home')).toEqual(
+			navigate('PROJECT', { projectName: 'Project123' }, { query: { returnTo: 'home' } })
+		);
+	});
+
 	test('defined route, with params, with state', () => {
-		expect(pathToAction(routesMap, '/portal/projects/Project123', { custom: 123 })).toEqual(
-			navigate('PROJECT', { projectName: 'Project123', custom: 123 })
+		expect(
+			pathToAction(routesMap, '/portal/projects/Project123', '?returnTo=home', {
+				custom: 123,
+			})
+		).toEqual(
+			navigate(
+				'PROJECT',
+				{ projectName: 'Project123', custom: 123 },
+				{ query: { returnTo: 'home' } }
+			)
 		);
 	});
 

--- a/src/__tests__/reducer.test.js
+++ b/src/__tests__/reducer.test.js
@@ -4,8 +4,8 @@ describe('reducer', () => {
 	test('should return the initial state', () => {
 		expect(reducer(undefined, {})).toEqual({
 			id: null,
-			path: null,
 			params: null,
+			query: null,
 			prev: null,
 		});
 	});
@@ -13,16 +13,20 @@ describe('reducer', () => {
 	test('should handle NAVIGATE', () => {
 		const state = {
 			id: null,
-			path: null,
 			params: null,
+			query: null,
 			prev: null,
 		};
-		const action = navigate('PROJECT', { projectName: 'Project 123' });
+		const action = navigate(
+			'PROJECT',
+			{ projectName: 'Project 123' },
+			{ query: { returnTo: 'home' } }
+		);
 
 		expect(reducer(state, action)).toEqual({
 			id: 'PROJECT',
-			path: null,
 			params: { projectName: 'Project 123' },
+			query: { returnTo: 'home' },
 			prev: null,
 		});
 	});
@@ -30,20 +34,24 @@ describe('reducer', () => {
 	test('should handle NAVIGATE and store previous route', () => {
 		const state = {
 			id: 'PROJECTS',
-			path: null,
 			params: {},
+			query: null,
 			prev: null,
 		};
-		const action = navigate('PROJECT', { projectName: 'Project 123' });
+		const action = navigate(
+			'PROJECT',
+			{ projectName: 'Project 123' },
+			{ query: { returnTo: 'home' } }
+		);
 
 		expect(reducer(state, action)).toEqual({
 			id: 'PROJECT',
-			path: null,
 			params: { projectName: 'Project 123' },
+			query: { returnTo: 'home' },
 			prev: {
 				id: 'PROJECTS',
-				path: null,
 				params: {},
+				query: null,
 				prev: null,
 			},
 		});
@@ -52,8 +60,8 @@ describe('reducer', () => {
 	test('should ignore UNKNOWN actions', () => {
 		const state = {
 			id: 'PROJECTS',
-			path: null,
 			params: {},
+			query: null,
 			prev: null,
 		};
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,6 +1103,10 @@ decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://npm.chaosgroup.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
@@ -2789,6 +2793,13 @@ qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
+query-string@^6.1.0:
+  version "6.1.0"
+  resolved "https://npm.chaosgroup.com/query-string/-/query-string-6.1.0.tgz#01e7d69f6a0940dac67a937d6c6325647aa4532a"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    strict-uri-encode "^2.0.0"
+
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
@@ -3186,6 +3197,10 @@ stream-combiner@~0.0.4:
   resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
   dependencies:
     duplexer "~0.1.1"
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://npm.chaosgroup.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
 
 string-length@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
As URL query string (not ordered/arbitrary data) is not supported by `path-to-regexp` lib this implementation excludes them from route matching but adds support for using query string as additional `NAVIGATE` action parameters. For example:

URL `/portal/projects/Project%20123?returnTo=home` will be matched by `route('PROJECT', '/portal/projects/:projectName')` and dispatch action `navigate('PROJECT', { projectName: 'Project 123' }, { query: { returnTo: 'home' } })` and vice versa.