### PR TITLE
router: array query params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "redux-saga-first-router",
-	"version": "0.0.20",
+	"version": "0.0.21",
 	"description": "'Saga First' Router for React/Redux/Saga Projects",
 	"main": "lib/index.js",
 	"module": "lib/es/index.js",

--- a/src/__tests__/query.test.js
+++ b/src/__tests__/query.test.js
@@ -18,6 +18,16 @@ describe('queryStringify', () => {
 		expect(queryStringify({ foo: null })).toEqual('foo');
 		expect(queryStringify({ foo: undefined })).toEqual('');
 	});
+
+	describe('with array params', () => {
+		it('outputs correct URI Generic Syntax', () => {
+			expect(queryStringify({ foo: ['bar1', 'bar2'] })).toEqual('foo=bar1&foo=bar2');
+		});
+
+		it('outputs correct URI Generic Syntax with equal parameters', () => {
+			expect(queryStringify({ foo: ['bar1', 'bar1'] })).toEqual('foo=bar1');
+		});
+	});
 });
 
 describe('queryParse', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -120,15 +120,20 @@ export function equal(a, b) {
 
 export function queryStringify(query) {
 	const encode = input => encodeURIComponent(input);
-	query = query || {};
+  query = query || {};
 	return Object.keys(query)
 		.sort()
 		.filter(key => query[key] !== undefined)
 		.map(key => {
-			return [key]
-				.concat(query[key] !== null ? [query[key]] : [])
-				.map(encode)
-				.join('=');
+      return (Array.isArray(query[key]) ? query[key] : [query[key]])
+        .filter((value, index, arr) => arr.indexOf(value) === index)
+        .map(val => {
+          return [key]
+            .concat(val !== null ? [val] : [])
+            .map(encode)
+            .join('=');
+        })
+        .join('&');
 		})
 		.join('&');
 }


### PR DESCRIPTION
Adds support for parsing query array params.

```javascript
{
  ...
  query: {
    foo: ['bar', 'batman'],
  },
}
```
will be `stringified` as `foo=bar&foo=batman`
