### PR TITLE
Fix init of regenerator-runtime

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import "regenerator-runtime/runtime.js";
 import { NAVIGATE, navigate, route, buildRoutesMap, actionToPath, pathToAction } from './core';
 import { reducer } from './reducer';
 import { saga } from './saga';


### PR DESCRIPTION
Dependency `babel-runtime` depends on `regenerator-runtime`, which needs to be imported to have it's regeneratorRuntime global variable initialized.
Probably didn't notice, because of it was imported somewhere else in codebase.