### PR TITLE
Skip query params with null or undefined value

### DIFF
--- a/src/__tests__/actionToPath.test.js
+++ b/src/__tests__/actionToPath.test.js
@@ -36,7 +36,8 @@ describe('actionToPath', () => {
 		expect(
 			actionToPath(
 				routesMap,
-				navigate('PROJECT', { projectName: 'Project 123' }, { query: { returnTo: 'home' } })
+				navigate('PROJECT', { projectName: 'Project 123' },
+					{ query: { returnTo: 'home', missing: undefined, unspecified: null } })
 			)
 		).toEqual({
 			pathname: '/portal/projects/Project%20123',

--- a/src/core.js
+++ b/src/core.js
@@ -31,6 +31,9 @@ function stringifyQuery(query) {
 	const params = new URLSearchParams();
 	for (const key in query) {
 		const val = query[key];
+		if (val === undefined || val === null) {
+			continue;
+		}
 		if (Array.isArray(val)) {
 			for (const _val of val) {
 				params.append(key, _val);


### PR DESCRIPTION
This PR changes the URL serialization logic to ignore query parameters that have `null` or `undefined` values. The former behavior was to serialize them as `"null"` and `"undefined"` respectively, which opened library users to unexpected bugs and behavior.